### PR TITLE
Add dependencies for packages

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -4,10 +4,10 @@ SERVER_TAR_NAME = yugabyte-$(YB_VERSION)-linux.tar.gz
 CLIENT_TAR_NAME = yugabyte-client-$(YB_VERSION)-linux.tar.gz
 DOWNLOADS_URL = "https://downloads.yugabyte.com"
 
-YB_SERVER_RPM_REVISION = 1
-YB_CLIENT_RPM_REVISION = 1
-YB_SERVER_DEB_REVISION = 1
-YB_CLIENT_DEB_REVISION = 1
+YB_SERVER_RPM_REVISION = 2
+YB_CLIENT_RPM_REVISION = 2
+YB_SERVER_DEB_REVISION = 2
+YB_CLIENT_DEB_REVISION = 2
 
 ARCH = x86_64
 EL_VERSION = 7
@@ -48,6 +48,9 @@ rpm: prepare_server
 	    --package "$(RPM_PACKAGE_PATH)" \
 	    --architecture "$(ARCH)" \
 	    --config-files "/etc/yugabytedb/yugabytedb.conf" \
+	    --depends "python" \
+	    --depends "procps-ng" \
+	    --depends "java-headless = 1:1.8.0" \
 	    "build/server-$(YB_VERSION)/=/opt/yugabytedb" \
 	    "server/yugabytedb.conf=/etc/yugabytedb/" \
 	    "server/yugabyted.service=/lib/systemd/system/"
@@ -74,6 +77,7 @@ client_rpm: prepare_client
 	    --rpm-rpmbuild-define "_build_id_links none" \
 	    --package "$(RPM_PACKAGE_PATH)" \
 	    --architecture "$(ARCH)" \
+	    --depends "python" \
 	    "build/client-$(YB_VERSION)/=/opt/yugabytedb-client"
 
 test_rpm:
@@ -101,6 +105,9 @@ deb: prepare_server
 	    --package "$(DEB_PACKAGE_PATH)" \
 	    --architecture "$(ARCH)" \
 	    --config-files "/etc/yugabytedb/yugabytedb.conf" \
+	    --depends "python" \
+	    --depends "procps" \
+	    --depends "default-jre" \
 	    "build/server-$(YB_VERSION)/=/opt/yugabytedb" \
 	    "server/yugabytedb.conf=/etc/yugabytedb/"
 
@@ -122,6 +129,7 @@ client_deb: prepare_client
 	    --iteration "$(YB_CLIENT_DEB_REVISION)" \
 	    --package "$(DEB_PACKAGE_PATH)" \
 	    --architecture "$(ARCH)" \
+	    --depends "python" \
 	    "build/client-$(YB_VERSION)/=/opt/yugabytedb-client"
 
 test_deb:

--- a/packages/server/yugabyted.service
+++ b/packages/server/yugabyted.service
@@ -7,6 +7,7 @@ Type=forking
 User=yugabyte
 ExecStart=/usr/bin/python /opt/yugabytedb/bin/yugabyted start --config /etc/yugabytedb/yugabytedb.conf
 PIDFile=/opt/yugabytedb/yugabyted.pid
+TimeoutStartSec=5min
 ExecStop=/usr/bin/python /opt/yugabytedb/bin/yugabyted stop --config /etc/yugabytedb/yugabytedb.conf
 TimeoutStopSec=10
 SuccessExitStatus=SIGKILL

--- a/packages/tests/test_deb_packages.sh
+++ b/packages/tests/test_deb_packages.sh
@@ -6,8 +6,7 @@ script_dirname="$(dirname "${script_name}")"
 
 source "${script_dirname}/utils.sh"
 
-packagedir="build/apt"
-test_log_file="${script_name}.log"
+packagedir="$(pwd)/build/apt"
 
 # remove uninstalls given package by adding given extra_args to 'apt
 # remove' command
@@ -19,9 +18,9 @@ remove() {
   extra_args="$2"
   info "remove: removing '${package}' package with '${extra_args}' to 'apt remove' command."
   if [[ "${package}" == "server" ]]; then
-    sudo apt remove yugabytedb -y ${extra_args} >> "${test_log_file}"
+    sudo apt remove --auto-remove yugabytedb -y ${extra_args}
   elif [[ "${package}" == "client" ]]; then
-    sudo apt remove yugabytedb-client -y ${extra_args} >> "${test_log_file}"
+    sudo apt remove --auto-remove yugabytedb-client -y ${extra_args}
   else
     echo "Invalid argument. Must be either 'server' or 'client'" 1>&2
     exit 1
@@ -56,7 +55,7 @@ install(){
     exit 1
   fi
   info "install: installing '${package}: ${package_name}'."
-  sudo dpkg -i "${packagedir}/${package_name}"  >> "${test_log_file}"
+  sudo apt install "${packagedir}/${package_name}" -y
   info "install: installed '${package}: ${package_name}'."
 }
 
@@ -95,12 +94,14 @@ install "server"
 check_ownership
 check_symlinks "server"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 install "client"
 check_ownership
 check_symlinks "client"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 remove "server" "--purge"
@@ -116,12 +117,14 @@ install "server"
 check_ownership
 check_symlinks "client"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 remove "client" "--purge"
 check_ownership
 check_symlinks "server"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 cleanup
 # END of test 2, 4, 6

--- a/packages/tests/test_rpm_packages.sh
+++ b/packages/tests/test_rpm_packages.sh
@@ -6,8 +6,7 @@ script_dirname="$(dirname "${script_name}")"
 
 source "${script_dirname}/utils.sh"
 
-packagedir="build/yum/el7-x86_64"
-test_log_file="${script_name}.log"
+packagedir="$(pwd)/build/yum/el7-x86_64"
 
 # remove uninstalls given package
 # argument 1: package: should be either 'server' or 'client'
@@ -15,9 +14,9 @@ remove() {
   package="$1"
   info "remove: removing '${package}' package."
   if [[ "${package}" == "server" ]]; then
-    sudo yum remove yugabytedb -y >> "${test_log_file}"
+    sudo yum remove yugabytedb -y
   elif [[ "${package}" == "client" ]]; then
-    sudo yum remove yugabytedb-client -y >> "${test_log_file}"
+    sudo yum remove yugabytedb-client -y
   else
     echo "Invalid argument. Must be either 'server' or 'client'" 1>&2
     exit 1
@@ -52,7 +51,7 @@ install(){
     exit 1
   fi
   info "install: installing '${package}: ${package_name}'."
-  sudo yum install "${packagedir}/${package_name}" -y >> "${test_log_file}"
+  sudo yum install "${packagedir}/${package_name}" -y
   info "install: installed '${package}: ${package_name}'."
 }
 
@@ -91,12 +90,14 @@ install "server"
 check_ownership
 check_symlinks "server"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 install "client"
 check_ownership
 check_symlinks "client"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 remove "server" "--purge"
@@ -112,12 +113,14 @@ install "server"
 check_ownership
 check_symlinks "client"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 remove "client" "--purge"
 check_ownership
 check_symlinks "server"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 cleanup
 # END of test 2, 4, 6

--- a/packages/tests/utils.sh
+++ b/packages/tests/utils.sh
@@ -5,6 +5,7 @@ file_owner_string="${yugabyte_user} ${yugabyte_user}"
 logdir="/var/log/yugabytedb"
 datadir="/var/lib/yugabytedb"
 configdir="/etc/yugabytedb"
+ui_endpoint="http://localhost:7200"
 
 Red="\e[31m"
 Gre="\e[32m"
@@ -119,6 +120,30 @@ check_systemd_service() {
     fail "check_systemd_service: yugabyted service is '${is_active}'."
   else
     pass "check_systemd_service: yugabyted service is '${is_active}'."
+  fi
+}
+
+# check_ui queries UI endpoint and checks if it retruns 200 HTTP
+# status code
+check_ui() {
+  info "check_ui: querying UI endpoint: '${ui_endpoint}'"
+  curl_output_file="$(pwd)/check_ui-$(date +%s)"
+  info "check_ui: writing the response body to '${curl_output_file}'"
+  response="$(
+    curl \
+      --write-out %{http_code} \
+      --silent --show-error \
+      --output ${curl_output_file} \
+      ${ui_endpoint}
+  )"
+  if [[ "${response}" == "200" ]]; then
+    pass "check_ui: UI endpoint '${ui_endpoint}' returned: '${response}'."
+  else
+    fail "check_ui: UI endpoint '${ui_endpoint}' returned: '${response}', expected: '200'."
+  fi
+  if [[ -f "${curl_output_file}" ]]; then
+    info "check_ui: contents of the response body:"
+    cat "${curl_output_file}"
   fi
 }
 


### PR DESCRIPTION
- Adds python, java and procps for server packages.
- Debian jessie users can install the package with following commands,
  this will install openjdk-8-jre instead of openjdk-7-jre which is
  default on jessie.
  ```
  sudo apt install openjdk-8-jre
  sudo apt install yugabytedb --no-install-recommends
  ```
- Adds python for client packages.
- Update tests to check the UI endpoint as well.
- Set TimeoutStartSec to 5min in systemd service file as UI takes some
  extra time to start.

