### PR TITLE
CI for RPM and Debian packages using GitHub actions

### DIFF
--- a/.github/workflows/packages-deb-build-and-test.yaml
+++ b/.github/workflows/packages-deb-build-and-test.yaml
@@ -1,0 +1,35 @@
+name: "Build and test Debian packages"
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - "packages/**"
+    - ".github/workflows/packages-*.yaml"
+  pull_request:
+    paths:
+    - "packages/**"
+    - ".github/workflows/packages-*.yaml"
+jobs:
+  deb-build-and-test:
+    strategy:
+      matrix:
+        image:
+        - "jrei/systemd-ubuntu:16.04"
+        - "jrei/systemd-ubuntu:18.04"
+        - "jrei/systemd-debian:9"
+        - "jrei/systemd-debian:10"
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: "Start docker container"
+      run: docker run -d --name debian-test-runner --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $(pwd):/workspace --workdir /workspace/packages ${{ matrix.image }}
+    - name: "Setup required packages"
+      run: docker exec debian-test-runner bash -c './build/bootstrap_deb_ci.sh'
+    - name: "Build the server and client packages"
+      run: docker exec debian-test-runner bash -c 'source ${HOME}/.bashrc; make download && make deb client_deb'
+    - name: "Run the tests"
+      run: docker exec debian-test-runner bash -c 'make test_deb'
+    - name: "Stop the container"
+      run: docker rm -f debian-test-runner

--- a/.github/workflows/packages-rpm-build-and-test.yaml
+++ b/.github/workflows/packages-rpm-build-and-test.yaml
@@ -1,0 +1,37 @@
+name: "Build and test RPM packages"
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - "packages/**"
+    - ".github/workflows/packages-*.yaml"
+  pull_request:
+    paths:
+    - "packages/**"
+    - ".github/workflows/packages-*.yaml"
+jobs:
+  rpm-build-and-test:
+    strategy:
+      matrix:
+        image:
+        - "jrei/systemd-centos:7"
+        - "jrei/systemd-fedora:latest"
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: "Start docker container"
+      run: docker run -d --name rpm-test-runner --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $(pwd):/workspace --workdir /workspace/packages ${{ matrix.image }}
+    # Workaround for failing yum commands on Fedora
+    - name: "Update yum cache on Fedora"
+      if: contains(matrix.image, 'fedora')
+      run: docker exec rpm-test-runner bash -c 'yum check-update || true'
+    - name: "Setup required packages"
+      run: docker exec rpm-test-runner bash -c './build/bootstrap_rpm_ci.sh'
+    - name: "Build the server and client packages"
+      run: docker exec rpm-test-runner bash -c 'source ${HOME}/.bashrc; make download && make rpm client_rpm'
+    - name: "Run the tests"
+      run: docker exec rpm-test-runner bash -c 'make test_rpm'
+    - name: "Stop the container"
+      run: docker rm -f rpm-test-runner

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -4,10 +4,10 @@ SERVER_TAR_NAME = yugabyte-$(YB_VERSION)-linux.tar.gz
 CLIENT_TAR_NAME = yugabyte-client-$(YB_VERSION)-linux.tar.gz
 DOWNLOADS_URL = "https://downloads.yugabyte.com"
 
-YB_SERVER_RPM_REVISION = 1
-YB_CLIENT_RPM_REVISION = 1
-YB_SERVER_DEB_REVISION = 1
-YB_CLIENT_DEB_REVISION = 1
+YB_SERVER_RPM_REVISION = 2
+YB_CLIENT_RPM_REVISION = 2
+YB_SERVER_DEB_REVISION = 2
+YB_CLIENT_DEB_REVISION = 2
 
 ARCH = x86_64
 EL_VERSION = 7
@@ -48,6 +48,9 @@ rpm: prepare_server
 	    --package "$(RPM_PACKAGE_PATH)" \
 	    --architecture "$(ARCH)" \
 	    --config-files "/etc/yugabytedb/yugabytedb.conf" \
+	    --depends "python" \
+	    --depends "procps-ng" \
+	    --depends "java-headless = 1:1.8.0" \
 	    "build/server-$(YB_VERSION)/=/opt/yugabytedb" \
 	    "server/yugabytedb.conf=/etc/yugabytedb/" \
 	    "server/yugabyted.service=/lib/systemd/system/"
@@ -74,6 +77,7 @@ client_rpm: prepare_client
 	    --rpm-rpmbuild-define "_build_id_links none" \
 	    --package "$(RPM_PACKAGE_PATH)" \
 	    --architecture "$(ARCH)" \
+	    --depends "python" \
 	    "build/client-$(YB_VERSION)/=/opt/yugabytedb-client"
 
 test_rpm:
@@ -101,6 +105,9 @@ deb: prepare_server
 	    --package "$(DEB_PACKAGE_PATH)" \
 	    --architecture "$(ARCH)" \
 	    --config-files "/etc/yugabytedb/yugabytedb.conf" \
+	    --depends "python" \
+	    --depends "procps" \
+	    --depends "default-jre" \
 	    "build/server-$(YB_VERSION)/=/opt/yugabytedb" \
 	    "server/yugabytedb.conf=/etc/yugabytedb/"
 
@@ -122,6 +129,7 @@ client_deb: prepare_client
 	    --iteration "$(YB_CLIENT_DEB_REVISION)" \
 	    --package "$(DEB_PACKAGE_PATH)" \
 	    --architecture "$(ARCH)" \
+	    --depends "python" \
 	    "build/client-$(YB_VERSION)/=/opt/yugabytedb-client"
 
 test_deb:

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -16,8 +16,8 @@ DEB_PACKAGE_PATH = build/apt/
 
 download:
 	@echo "Downloading YugaByte release tars for the version $(YB_VERSION)"
-	wget --directory-prefix "build" $(DOWNLOADS_URL)/$(SERVER_TAR_NAME)
-	wget --directory-prefix "build" $(DOWNLOADS_URL)/$(CLIENT_TAR_NAME)
+	wget --progress "dot:giga" --directory-prefix "build" $(DOWNLOADS_URL)/$(SERVER_TAR_NAME)
+	wget --progress "dot:giga" --directory-prefix "build" $(DOWNLOADS_URL)/$(CLIENT_TAR_NAME)
 
 prepare:
 	@echo "Creating target directories for the packages."
@@ -27,7 +27,7 @@ prepare:
 prepare_server: prepare
 	@echo "Extracting the release tar '$(SERVER_TAR_NAME)' for server package."
 	mkdir -p build/server-$(YB_VERSION)
-	tar -xvzf build/$(SERVER_TAR_NAME) -C build/server-$(YB_VERSION) --strip-components 1
+	tar -xzf build/$(SERVER_TAR_NAME) -C build/server-$(YB_VERSION) --strip-components 1
 
 rpm: prepare_server
 	@echo "Building RPM package for yugabytedb version '$(YB_VERSION)', revision '$(YB_SERVER_RPM_REVISION)'"
@@ -58,7 +58,7 @@ rpm: prepare_server
 prepare_client: prepare
 	@echo "Extracting the release tar '$(CLIENT_TAR_NAME)' for client package."
 	mkdir -p build/client-$(YB_VERSION)
-	tar -xvzf build/$(CLIENT_TAR_NAME) -C build/client-$(YB_VERSION) --strip-components 1
+	tar -xzf build/$(CLIENT_TAR_NAME) -C build/client-$(YB_VERSION) --strip-components 1
 
 client_rpm: prepare_client
 	@echo "Building RPM package for yugabytedb-client version '$(YB_VERSION)', revision '$(YB_SERVER_RPM_REVISION)'"

--- a/packages/build/bootstrap_deb_ci.sh
+++ b/packages/build/bootstrap_deb_ci.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -x -o pipefail -o errexit
+
+apt update
+apt install wget curl time sudo -y
+apt install rubygems ruby-dev gcc make -y
+
+echo 'export GEM_HOME="${HOME}/.ruby/"' >> "${HOME}/.bashrc"
+echo 'export PATH="$PATH:${HOME}/.ruby/bin"' >> "${HOME}/.bashrc"
+source "${HOME}/.bashrc"
+
+gem install --no-document fpm
+fpm --version

--- a/packages/build/bootstrap_rpm_ci.sh
+++ b/packages/build/bootstrap_rpm_ci.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x -o pipefail -o errexit
+
+yum install wget curl sudo which -y
+yum install rubygems ruby-devel gcc redhat-rpm-config make rpm-build -y
+
+echo 'export PATH="$PATH:${HOME}/bin"' >> "${HOME}/.bashrc"
+source "${HOME}/.bashrc"
+
+gem install --no-document fpm
+fpm --version

--- a/packages/server/yugabyted.service
+++ b/packages/server/yugabyted.service
@@ -7,6 +7,7 @@ Type=forking
 User=yugabyte
 ExecStart=/usr/bin/python /opt/yugabytedb/bin/yugabyted start --config /etc/yugabytedb/yugabytedb.conf
 PIDFile=/opt/yugabytedb/yugabyted.pid
+TimeoutStartSec=5min
 ExecStop=/usr/bin/python /opt/yugabytedb/bin/yugabyted stop --config /etc/yugabytedb/yugabytedb.conf
 TimeoutStopSec=10
 SuccessExitStatus=SIGKILL

--- a/packages/tests/test_deb_packages.sh
+++ b/packages/tests/test_deb_packages.sh
@@ -6,8 +6,7 @@ script_dirname="$(dirname "${script_name}")"
 
 source "${script_dirname}/utils.sh"
 
-packagedir="build/apt"
-test_log_file="${script_name}.log"
+packagedir="$(pwd)/build/apt"
 
 # remove uninstalls given package by adding given extra_args to 'apt
 # remove' command
@@ -19,9 +18,9 @@ remove() {
   extra_args="$2"
   info "remove: removing '${package}' package with '${extra_args}' to 'apt remove' command."
   if [[ "${package}" == "server" ]]; then
-    sudo apt remove yugabytedb -y ${extra_args} >> "${test_log_file}"
+    sudo apt remove --auto-remove yugabytedb -y ${extra_args}
   elif [[ "${package}" == "client" ]]; then
-    sudo apt remove yugabytedb-client -y ${extra_args} >> "${test_log_file}"
+    sudo apt remove --auto-remove yugabytedb-client -y ${extra_args}
   else
     echo "Invalid argument. Must be either 'server' or 'client'" 1>&2
     exit 1
@@ -56,7 +55,7 @@ install(){
     exit 1
   fi
   info "install: installing '${package}: ${package_name}'."
-  sudo dpkg -i "${packagedir}/${package_name}"  >> "${test_log_file}"
+  sudo apt install "${packagedir}/${package_name}" -y
   info "install: installed '${package}: ${package_name}'."
 }
 
@@ -95,12 +94,14 @@ install "server"
 check_ownership
 check_symlinks "server"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 install "client"
 check_ownership
 check_symlinks "client"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 remove "server" "--purge"
@@ -116,12 +117,14 @@ install "server"
 check_ownership
 check_symlinks "client"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 remove "client" "--purge"
 check_ownership
 check_symlinks "server"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 cleanup
 # END of test 2, 4, 6

--- a/packages/tests/test_deb_packages.sh
+++ b/packages/tests/test_deb_packages.sh
@@ -95,14 +95,14 @@ check_ownership
 check_symlinks "server"
 check_systemd_service
 check_ui
-ysqlsh -c '\l'
+check_ysqlsh
 
 install "client"
 check_ownership
 check_symlinks "client"
 check_systemd_service
 check_ui
-ysqlsh -c '\l'
+check_ysqlsh
 
 remove "server" "--purge"
 check_symlinks "client_only"
@@ -118,14 +118,14 @@ check_ownership
 check_symlinks "client"
 check_systemd_service
 check_ui
-ysqlsh -c '\l'
+check_ysqlsh
 
 remove "client" "--purge"
 check_ownership
 check_symlinks "server"
 check_systemd_service
 check_ui
-ysqlsh -c '\l'
+check_ysqlsh
 cleanup
 # END of test 2, 4, 6
 

--- a/packages/tests/test_rpm_packages.sh
+++ b/packages/tests/test_rpm_packages.sh
@@ -91,14 +91,14 @@ check_ownership
 check_symlinks "server"
 check_systemd_service
 check_ui
-ysqlsh -c '\l'
+check_ysqlsh
 
 install "client"
 check_ownership
 check_symlinks "client"
 check_systemd_service
 check_ui
-ysqlsh -c '\l'
+check_ysqlsh
 
 remove "server" "--purge"
 check_symlinks "client_only"
@@ -114,14 +114,14 @@ check_ownership
 check_symlinks "client"
 check_systemd_service
 check_ui
-ysqlsh -c '\l'
+check_ysqlsh
 
 remove "client" "--purge"
 check_ownership
 check_symlinks "server"
 check_systemd_service
 check_ui
-ysqlsh -c '\l'
+check_ysqlsh
 cleanup
 # END of test 2, 4, 6
 

--- a/packages/tests/test_rpm_packages.sh
+++ b/packages/tests/test_rpm_packages.sh
@@ -6,8 +6,7 @@ script_dirname="$(dirname "${script_name}")"
 
 source "${script_dirname}/utils.sh"
 
-packagedir="build/yum/el7-x86_64"
-test_log_file="${script_name}.log"
+packagedir="$(pwd)/build/yum/el7-x86_64"
 
 # remove uninstalls given package
 # argument 1: package: should be either 'server' or 'client'
@@ -15,9 +14,9 @@ remove() {
   package="$1"
   info "remove: removing '${package}' package."
   if [[ "${package}" == "server" ]]; then
-    sudo yum remove yugabytedb -y >> "${test_log_file}"
+    sudo yum remove yugabytedb -y
   elif [[ "${package}" == "client" ]]; then
-    sudo yum remove yugabytedb-client -y >> "${test_log_file}"
+    sudo yum remove yugabytedb-client -y
   else
     echo "Invalid argument. Must be either 'server' or 'client'" 1>&2
     exit 1
@@ -52,7 +51,7 @@ install(){
     exit 1
   fi
   info "install: installing '${package}: ${package_name}'."
-  sudo yum install "${packagedir}/${package_name}" -y >> "${test_log_file}"
+  sudo yum install "${packagedir}/${package_name}" -y
   info "install: installed '${package}: ${package_name}'."
 }
 
@@ -91,12 +90,14 @@ install "server"
 check_ownership
 check_symlinks "server"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 install "client"
 check_ownership
 check_symlinks "client"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 remove "server" "--purge"
@@ -112,12 +113,14 @@ install "server"
 check_ownership
 check_symlinks "client"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 
 remove "client" "--purge"
 check_ownership
 check_symlinks "server"
 check_systemd_service
+check_ui
 ysqlsh -c '\l'
 cleanup
 # END of test 2, 4, 6

--- a/packages/tests/utils.sh
+++ b/packages/tests/utils.sh
@@ -5,6 +5,7 @@ file_owner_string="${yugabyte_user} ${yugabyte_user}"
 logdir="/var/log/yugabytedb"
 datadir="/var/lib/yugabytedb"
 configdir="/etc/yugabytedb"
+ui_endpoint="http://localhost:7200"
 
 Red="\e[31m"
 Gre="\e[32m"
@@ -119,6 +120,30 @@ check_systemd_service() {
     fail "check_systemd_service: yugabyted service is '${is_active}'."
   else
     pass "check_systemd_service: yugabyted service is '${is_active}'."
+  fi
+}
+
+# check_ui queries UI endpoint and checks if it retruns 200 HTTP
+# status code
+check_ui() {
+  info "check_ui: querying UI endpoint: '${ui_endpoint}'"
+  curl_output_file="$(pwd)/check_ui-$(date +%s)"
+  info "check_ui: writing the response body to '${curl_output_file}'"
+  response="$(
+    curl \
+      --write-out %{http_code} \
+      --silent --show-error \
+      --output ${curl_output_file} \
+      ${ui_endpoint}
+  )"
+  if [[ "${response}" == "200" ]]; then
+    pass "check_ui: UI endpoint '${ui_endpoint}' returned: '${response}'."
+  else
+    fail "check_ui: UI endpoint '${ui_endpoint}' returned: '${response}', expected: '200'."
+  fi
+  if [[ -f "${curl_output_file}" ]]; then
+    info "check_ui: contents of the response body:"
+    cat "${curl_output_file}"
   fi
 }
 


### PR DESCRIPTION
- Add tests using ysqlsh
  - Loads the demo database and checks if specific data entry is present or not
- Add CI workflow for packages using GitHub actions 
  - Enabled for push to master and pull requests
  - Triggered only when there is any change in packages directory or the workflow file itself
  - Trying to decrease some noise from CI logs by tweaking flags to tar and wget

This PR depends on #13 