### PR TITLE
New download path

### DIFF
--- a/common_scripts/install_software.sh
+++ b/common_scripts/install_software.sh
@@ -5,10 +5,11 @@
 # This is a simple script to install yugabyte-db software on a machine.
 #
 ###############################################################################
-
-YB_VERSION=$1
+YB_RELEASE=$1
+YB_VERSION=${YB_RELEASE%-*}
 YB_HOME=/home/${USER}/yugabyte-db
-YB_PACKAGE_URL="https://downloads.yugabyte.com/yugabyte-${YB_VERSION}-linux.tar.gz"
+YB_DL_BASE="https://downloads.yugabyte.com/releases"
+YB_PACKAGE_URL="${YB_DL_BASE}/${YB_VERSION}/yugabyte-${YB_RELEASE}-linux-x86_64.tar.gz"
 YB_PACKAGE_NAME="${YB_PACKAGE_URL##*/}"
 
 ###############################################################################

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,24 +1,28 @@
 
-YB_VERSION ?= 2.1.5.0
-YB_CLIENT_VERSION ?= 2.1
-SERVER_TAR_NAME = yugabyte-$(YB_VERSION)-linux.tar.gz
+YB_RELEASE ?= 2.11.0.0-b7
+YB_VERSION = $(word 1, $(subst -b, ,$(YB_RELEASE)))
+YB_BUILD_NO = $(word 2, $(subst -b, ,$(YB_RELEASE)))
+YB_CLIENT_VERSION ?= 2.6
+ARCH ?= x86_64
+SERVER_TAR_NAME = yugabyte-$(YB_VERSION)-b$(YB_BUILD_NO)-linux-$(ARCH).tar.gz
 CLIENT_TAR_NAME = yugabyte-client-$(YB_CLIENT_VERSION)-linux.tar.gz
-DOWNLOADS_URL = "https://downloads.yugabyte.com"
+DOWNLOADS_BASE = https://downloads.yugabyte.com
+SERVER_URL = $(DOWNLOADS_BASE)/releases/$(YB_VERSION)/$(SERVER_TAR_NAME)
+CLIENT_URL = $(DOWNLOADS_BASE)/$(CLIENT_TAR_NAME)
 
 YB_SERVER_RPM_REVISION = 2
 YB_CLIENT_RPM_REVISION = 2
 YB_SERVER_DEB_REVISION = 2
 YB_CLIENT_DEB_REVISION = 2
 
-ARCH = x86_64
 EL_VERSION = 7
 RPM_PACKAGE_PATH = build/yum/el$(EL_VERSION)-$(ARCH)/
 DEB_PACKAGE_PATH = build/apt/
 
 download:
 	@echo "Downloading YugaByte release tars for the version $(YB_VERSION)"
-	wget --progress "dot:giga" --directory-prefix "build" $(DOWNLOADS_URL)/$(SERVER_TAR_NAME)
-	wget --progress "dot:giga" --directory-prefix "build" $(DOWNLOADS_URL)/$(CLIENT_TAR_NAME)
+	wget --progress "dot:giga" --directory-prefix "build" $(SERVER_URL)
+	wget --progress "dot:giga" --directory-prefix "build" $(CLIENT_URL)
 
 prepare:
 	@echo "Creating target directories for the packages."

--- a/packages/README.md
+++ b/packages/README.md
@@ -63,7 +63,7 @@ To create the packages for YugabyteDB as well client
   It's possible to download specific version by exporting the variable
   `YB_VERSION` with desired version.
   ```console
-  $ export YB_VERSION="2.0.11.0"
+  $ export YB_RELEASE="2.11.0.0-b7"
   $ make download
   …
   ```

--- a/packages/build/bootstrap_rpm_ci.sh
+++ b/packages/build/bootstrap_rpm_ci.sh
@@ -8,5 +8,5 @@ yum install rubygems ruby-devel gcc redhat-rpm-config make rpm-build -y
 echo 'export PATH="$PATH:${HOME}/bin"' >> "${HOME}/.bashrc"
 source "${HOME}/.bashrc"
 
-gem install --no-document fpm
+gem install --no-document git:'<1.8.0' fpm
 fpm --version

--- a/scripts/install_software.sh
+++ b/scripts/install_software.sh
@@ -5,9 +5,11 @@
 # This is a simple script to install yugabyte-db software on a machine.
 #
 ###############################################################################
-YB_VERSION=$1
+YB_RELEASE=$1
+YB_VERSION=${YB_RELEASE%-*}
 YB_HOME=/home/${USER}/yugabyte-db
-YB_PACKAGE_URL="https://downloads.yugabyte.com/yugabyte-${YB_VERSION}-linux.tar.gz"
+YB_DL_BASE="https://downloads.yugabyte.com/releases"
+YB_PACKAGE_URL="${YB_DL_BASE}/${YB_VERSION}/yugabyte-${YB_RELEASE}-linux-x86_64.tar.gz"
 YB_PACKAGE_NAME="${YB_PACKAGE_URL##*/}"
 
 ###############################################################################


### PR DESCRIPTION
Update the references to downloads.yugabyte.com to use the new package URL pattern.  Tested using 2.11.0.0-b7 and 2.9.1.0-b140.  For the Makefile, use a new user variable called `YB_RELEASE` that is used internally to set YB_VERSION and also YB_BUILD_NO.  This is b/c Yugabyte releases now contain the full version number including build number in the artifact names.

After this is merged, the various terraform-* repos will need to be updated as well.