### PR TITLE
Fixes (failed in AWS new images + deprecated gflag)

### DIFF
--- a/common_scripts/create_universe.sh
+++ b/common_scripts/create_universe.sh
@@ -46,7 +46,8 @@ fi
 case "${CLOUD_NAME}" in
 
   'AWS')
-    NODEIP="$(curl http://169.254.169.254/latest/meta-data/local-ipv4)"
+    TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+    NODEIP="$(curl -H 'X-aws-ec2-metadata-token: $TOKEN' http://169.254.169.254/latest/meta-data/local-ipv4)"
     ;;
 
   'Azure')

--- a/common_scripts/create_universe.sh
+++ b/common_scripts/create_universe.sh
@@ -47,7 +47,7 @@ case "${CLOUD_NAME}" in
 
   'AWS')
     TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
-    NODEIP="$(curl -H 'X-aws-ec2-metadata-token: $TOKEN' http://169.254.169.254/latest/meta-data/local-ipv4)"
+    NODEIP="$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)"
     ;;
 
   'Azure')

--- a/common_scripts/create_universe.sh
+++ b/common_scripts/create_universe.sh
@@ -147,7 +147,6 @@ echo "--placement_region=${REGION}" >> "${YB_HOME}/master/conf/server.conf"
 echo "--placement_region=${REGION}" >> "${YB_HOME}/tserver/conf/server.conf"
 echo "--placement_zone=${INSTANCE_ZONE}" >> "${YB_HOME}/master/conf/server.conf"
 echo "--placement_zone=${INSTANCE_ZONE}" >> "${YB_HOME}/tserver/conf/server.conf"
-echo "--use_initial_sys_catalog_snapshot" >> "${YB_HOME}/master/conf/server.conf"
 
 ###############################################################################
 # Setup rpc_bind_addresses across all the nodes.


### PR DESCRIPTION
The script failed on new Amazon images with:
````
warning: use_initial_sys_catalog_snapshot
Invalid port: expected port after ':' at position 0 in :7100
```
The error was: `--rpc_bind_addresses=:7100`
The reason was failure to get the IP from AWS metadata

Fix: Use IMDSv2 to get metadata on AWS
https://aws.amazon.com/about-aws/whats-new/2022/10/amazon-machine-images-support-instance-metadata-service-version-2-default/

Also removed `use_initial_sys_catalog_snapshot` which is deprecated
