### PR TITLE
[fix] take first result on YB_RELEASE check

### DIFF
--- a/scripts/install_software.sh
+++ b/scripts/install_software.sh
@@ -8,7 +8,7 @@
 YB_VERSION=$1
 # this query is paginated, so there's no guarantee we will find this release on the first page
 # needs improvement to walk through all pages
-YB_RELEASE=$(curl -s https://registry.hub.docker.com/v2/repositories/yugabytedb/yugabyte/tags |  grep -Eo "${YB_VERSION}-b[0-9]+")
+YB_RELEASE=$(curl -s https://registry.hub.docker.com/v2/repositories/yugabytedb/yugabyte/tags | grep -Eo "${YB_VERSION}-b[0-9]+" | head -n 1)
 YB_HOME=/home/${USER}/yugabyte-db
 YB_DL_BASE="https://downloads.yugabyte.com/releases"
 YB_PACKAGE_URL="${YB_DL_BASE}/${YB_VERSION}/yugabyte-${YB_RELEASE}-linux-x86_64.tar.gz"


### PR DESCRIPTION
Before running `./install_software.sh 2024.1.3.0` would have multi-line values for YB_RELEASE, YB_PACKAGE_URL, and YB_PACKAGE_NAME:
```
YB_RELEASE: 2024.1.3.0-b105
2024.1.3.0-b105
2024.1.3.0-b105
YB_PACKAGE_URL: https://downloads.yugabyte.com/releases/2024.1.3.0/yugabyte-2024.1.3.0-b105
2024.1.3.0-b105
2024.1.3.0-b105-linux-x86_64.tar.gz
YB_PACKAGE_NAME: yugabyte-2024.1.3.0-b105
2024.1.3.0-b105
2024.1.3.0-b105-linux-x86_64.tar.gz
```

This would cause the install script to fail since `YB_PACKAGE_URL` is not valid. `wget` would fail to grab `https://downloads.yugabyte.com/releases/2024.1.3.0/yugabyte-2024.1.3.0-b105` above.

By taking the first result using `| head -n 1` the install script works fine:
```
YB_RELEASE: 2024.1.3.0-b105
YB_PACKAGE_URL: https://downloads.yugabyte.com/releases/2024.1.3.0/yugabyte-2024.1.3.0-b105-linux-x86_64.tar.gz
YB_PACKAGE_NAME: yugabyte-2024.1.3.0-b105-linux-x86_64.tar.gz
```

In this case, `wget https://downloads.yugabyte.com/releases/2024.1.3.0/yugabyte-2024.1.3.0-b105-linux-x86_64.tar.gz` ends up succeeding

I believe the root cause is that we see these 3 versions mentioned in release tags:
- 2024.1.3.0-b105
- 2024.1.3.0-b105-aarch64
- 2024.1.3.0-b105-x86_64

So the `grep -Eo "2024.1.3.0-b[0-9]+"` matches all 3 and returns `2024.1.3.0-b105` 3 times.